### PR TITLE
prevent python-magic from upgrading over 0.4.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ stomp.py<5.0
 texttable>=0.8.8
 twilio==6.0.0
 thehive4py>=1.4.4
-python-magic>=0.4.15
+python-magic>=0.4.15,<=0.4.22
 cffi>=1.11.5
 urllib3<1.25


### PR DESCRIPTION
Newer versions of python-magic cause elastalert to fail with the following message:

```
/usr/local/lib/python2.7/site-packages/OpenSSL/crypto.py:14: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography import utils, x509
Traceback (most recent call last):
  File "/usr/local/bin/elastalert", line 11, in <module>
    load_entry_point('elastalert==0.1.38', 'console_scripts', 'elastalert')()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/site-packages/elastalert-0.1.38-py2.7.egg/elastalert/elastalert.py", line 21, in <module>
    from alerts import DebugAlerter
  File "/usr/local/lib/python2.7/site-packages/elastalert-0.1.38-py2.7.egg/elastalert/alerts.py", line 32, in <module>
    from thehive4py.api import TheHiveApi
  File "/usr/local/lib/python2.7/site-packages/thehive4py/api.py", line 7, in <module>
    import magic
  File "/usr/local/lib/python2.7/site-packages/magic/__init__.py", line 208, in <module>
    libmagic = loader.load_lib()
  File "/usr/local/lib/python2.7/site-packages/magic/loader.py", line 49, in load_lib
    raise ImportError('failed to find libmagic.  Check your installation')
ImportError: failed to find libmagic.  Check your installation
```

Preventing the dependency from being bumped to 0.4.24 fixes the issue (provided that we need a quick fix for the issue instead of wanting to look more deeply for the root cause and wanting to upgrade the rest of the dependencies, such as the system's `libmagic`).